### PR TITLE
[WIP] Create and read .sol file correctly to get solve status

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,29 +17,13 @@ Pkg.add("AmplNLWriter")
 AmplNLWriter.jl provides ``AmplNLSolver`` as a usable solver in JuMP. The following Julia code uses the Bonmin solver in JuMP via AmplNLWriter.jl:
 
     julia> using JuMP, AmplNLWriter
-    julia> m = Model(solver=AmplNLSolver("bonmin"), "-s")
+    julia> m = Model(solver=AmplNLSolver("bonmin"))
 
 You can then model and solve your optimization problem as usual. See [JuMP's documentation](http://jump.readthedocs.org/en/latest/) for more details. 
 
 The ``AmplNLSolver()`` constructor requires as the first argument the name of the solver command needed to run the desired solver. For example, if the ``bonmin`` executable is on the system path, you can use this solver using ``AmplNLSolver("bonmin")``. If the solver is not on the path, the full path to the solver will need to be passed in. This solver executable must be an AMPL-compatible solver.
 
-The second and third arguments to ``AmplNLSolver()``, `pre_command` and `post_command`, are optional strings that are specific to the solver you are using. ``AmplNLSolver`` will execute the following command when running the solver:
-
-    solver_command pre_command /path/to/model.nl post_command <options>
-
-For example, Bonmin needs to be run as follows:
-
-    bonmin -s /path/to/model.nl
-
-So we need to set `pre_command="-s"` and `post_command=""`. SCIP using the `scipampl` binary is run with:
-
-    scipampl /path/to/model.nl
-
-So both `pre_command` and `post_command` are `""`.
-
-For other solvers, you will need to determine the appropriate form for invoking the solver and set `pre_command` and `post_command` yourself.
-
-The final (optional) argument to ``AmplNLSolver()`` is a ``Dict{String, Any}`` of solver options. These should be specified with the name of the option as the key, and the desired value as the value. For example, to set the NLP log level to 0 in Bonmin, you would run ``AmplNLSolver("bonmin", "-s", "", Dict("bonmin.nlp_log_level"=>0))``. For a list of options supported by your solver, check the solver's documentation, or run ``/path/to/solver -=`` at the command line e.g. run ``bonmin -=`` for a list of all Bonmin options.
+The second (optional) argument to ``AmplNLSolver()`` is a ``Dict{String, Any}`` of solver options. These should be specified with the name of the option as the key, and the desired value as the value. For example, to set the NLP log level to 0 in Bonmin, you would run ``AmplNLSolver("bonmin", Dict("bonmin.nlp_log_level"=>0))``. For a list of options supported by your solver, check the solver's documentation, or run ``/path/to/solver -=`` at the command line e.g. run ``bonmin -=`` for a list of all Bonmin options.
 
 If you have [CoinOptServices.jl](https://github.com/JuliaOpt/CoinOptServices.jl) installed, you can easily use the Bonmin or Couenne solvers installed by this package:
 
@@ -51,4 +35,21 @@ Similarly, if you have [Ipopt.jl](https://github.com/JuliaOpt/Ipopt.jl) installe
 In the `examples` folder you can see a range of problems solved using this package via JuMP.
 
 The AmplNLSolver should also work with any other MathProgBase-compliant linear or nonlinear optimization modeling tools, though this has not been tested.
+
+### Checking solve results
+
+In addition to returning the status via `MathProgBase.status` (or `status = solve(m)` in JuMP), it is possible to extract the same post-solve variables that are present in AMPL:
+
+- `solve_result`: one of `solved`, `solved?`, `infeasible`, `unbounded`, `limit`, `failure`
+- `solve_result_num`: the numeric code returned by the solver. This is solver-specific and gives more granularity than `solve_result`
+- `solve_message`: the message printed by the solver at termination
+- `solve_exitcode`: the exitcode of the solve process
+
+These can be accessed as follows:
+
+    ampl_model = getInternalModel(m)  # If using JuMP, get a reference to the MathProgBase model
+    @show get_solve_result(ampl_model)
+    @show get_solve_result_num(ampl_model)
+    @show get_solve_message(ampl_model)
+    @show get_solve_exitcode(ampl_model)
 

--- a/src/nl_write.jl
+++ b/src/nl_write.jl
@@ -57,7 +57,7 @@ function write_nl_header(f, m::AmplNLMathProgModel)
     nlvb = sum(nonlinear_both)
     println(f, " $nlvc $nlvo $nlvb")
     # Line 6: linear network variables; functions; arith, flags
-    println(f, " 0 0 0 0")
+    println(f, " 0 0 0 1")  # flags set to 1 to get suffixes in .sol file
     # Line 7: discrete variables: binary, integer, nonlinear (b,c,o)
     binary = m.vartypes .== :Bin
     integer = m.vartypes .== :Int


### PR DESCRIPTION
An extension of #14. Using the ASL implementation as a guide, this reads the `.sol` file properly, allowing us to extract the status of the solve correctly without resorting to string matching.

It also makes available the following variables, named as per AMPL:

- `solve_result`: one of `solved`, `solved?`, `infeasible`, `unbounded`, `limit`, `failure`
- `solve_result_num`: the numeric code returned by the solver. This is solver-specific and gives more granularity than `solve_result`
- `solve_message`: the message printed by the solver at termination
- `solve_exitcode`: the exitcode of the solve process

As a result of figuring out the way to request suffixes in the `.sol` file, the solvers are now called in a standardized way, and so the `pre_command` and `post_command` business has been removed.

### TODOs

- Need to extract the exitcode of the solve process
- I'm not too happy about the names of `getsolveresult`, `getsolveresultnum` etc. I think these are probably better off with underscores?
- AMPL has a `solve_result` of `solved?`, meaning "optimal solution indicated, but error likely". Currently return `:Optimal` in this case, but maybe it's better to use something else? In these cases, the user should be checking the `solve_result_num` against the solver docs to make sure it's not anything bad. As a guide to when it might come up, here's what CPLEX does, codes from 0-99 are `solved` and 100-199 are `solved?`:

          0 optimal solution
          1 primal has unbounded optimal face
          2 optimal integer solution
          3 optimal integer solution within mipgap or absmipgap
        100 best solution found, primal-dual feasible
        110 optimal with unscaled infeasibilities
        111 integer optimal with unscaled infeasibilities

- Update docs
- Add tests for these new bits

We also need to figure out what to do with the duals. As far as I can tell, even when called from AMPL, only the duals are returned from the solver, and then these are used to get the reduced costs. So we probably need to calculate the reduced costs ourselves too.

@odow Can you check that your problems in #13 are generating the correct status now?